### PR TITLE
feat(generate): change generate --prefix option type from Boolean to …

### DIFF
--- a/packages/angular-cli/blueprints/component/index.js
+++ b/packages/angular-cli/blueprints/component/index.js
@@ -15,7 +15,7 @@ module.exports = {
     { name: 'flat', type: Boolean, default: false },
     { name: 'inline-template', type: Boolean, aliases: ['it'] },
     { name: 'inline-style', type: Boolean, aliases: ['is'] },
-    { name: 'prefix', type: Boolean, default: true },
+    { name: 'prefix', type: String, default: null },
     { name: 'spec', type: Boolean },
     { name: 'view-encapsulation', type: String, aliases: ['ve'] },
     { name: 'change-detection', type: String, aliases: ['cd'] },
@@ -41,9 +41,12 @@ module.exports = {
     if (this.project.ngConfig &&
         this.project.ngConfig.apps[0] &&
         this.project.ngConfig.apps[0].prefix) {
-      defaultPrefix = this.project.ngConfig.apps[0].prefix + '-';
+      defaultPrefix = this.project.ngConfig.apps[0].prefix;
     }
-    var prefix = this.options.prefix ? defaultPrefix : '';
+
+    var prefix = (this.options.prefix === 'false' || this.options.prefix === '') ? '' : (this.options.prefix || defaultPrefix);
+    prefix = prefix && `${prefix}-`;
+
     this.selector = stringUtils.dasherize(prefix + parsedPath.name);
 
     if (this.selector.indexOf('-') === -1) {

--- a/packages/angular-cli/blueprints/directive/index.js
+++ b/packages/angular-cli/blueprints/directive/index.js
@@ -12,7 +12,7 @@ module.exports = {
 
   availableOptions: [
     { name: 'flat', type: Boolean, default: true },
-    { name: 'prefix', type: Boolean, default: true },
+    { name: 'prefix', type: String, default: null },
     { name: 'spec', type: Boolean },
     { name: 'skip-import', type: Boolean, default: false }
   ],
@@ -38,7 +38,10 @@ module.exports = {
         this.project.ngConfig.apps[0].prefix) {
       defaultPrefix = this.project.ngConfig.apps[0].prefix;
     }
-    var prefix = this.options.prefix ? `${defaultPrefix}-` : '';
+
+    var prefix = (this.options.prefix === 'false' || this.options.prefix === '') ? '' : (this.options.prefix || defaultPrefix);
+    prefix = prefix && `${prefix}-`;
+
 
     this.selector = stringUtils.camelize(prefix + parsedPath.name);
     return parsedPath.name;

--- a/packages/angular-cli/blueprints/module/index.js
+++ b/packages/angular-cli/blueprints/module/index.js
@@ -68,7 +68,7 @@ module.exports = {
       options.route = false;
       options.inlineTemplate = false;
       options.inlineStyle = false;
-      options.prefix = true;
+      options.prefix = null;
       options.spec = true;
       return Blueprint.load(path.join(__dirname, '../component')).install(options);
     }

--- a/tests/acceptance/generate-component.spec.js
+++ b/tests/acceptance/generate-component.spec.js
@@ -150,6 +150,26 @@ describe('Acceptance: ng generate component', function () {
       });
   });
 
+  it('mycomp --prefix= will not prefix selector', () => {
+    return ng(['generate', 'component', 'mycomp', '--prefix='])
+      .then(() => {
+        var testPath = path.join(root, 'tmp', 'foo', 'src', 'app', 'mycomp', 'mycomp.component.ts');
+        expect(existsSync(testPath)).to.equal(true);
+        var contents = fs.readFileSync(testPath, 'utf8');
+        expect(contents.indexOf('selector: \'mycomp\'') === -1).to.equal(false);
+      });
+  });
+
+  it('mycomp --prefix=test will prefix selector with \'test-\'', () => {
+    return ng(['generate', 'component', 'mycomp', '--prefix=test'])
+      .then(() => {
+        var testPath = path.join(root, 'tmp', 'foo', 'src', 'app', 'mycomp', 'mycomp.component.ts');
+        expect(existsSync(testPath)).to.equal(true);
+        var contents = fs.readFileSync(testPath, 'utf8');
+        expect(contents.indexOf('selector: \'test-mycomp\'') === -1).to.equal(false);
+      });
+  });
+
   it('myComp will succeed', () => {
     return ng(['generate', 'component', 'myComp'])
       .then(() => {


### PR DESCRIPTION
…string (#3457)

use ``ng g c foo --prefix='bar'`` or ``ng g d foo --prefix='bar'`` in order to use
another prefix than the one defined by default in angular-cli.json apps[0].prefix
tslint rules "directive-selector" and "component-selector" can accept any array of prefix,
and is therefore compatible with this approach
this is a temporary solution pending #3452 closure